### PR TITLE
Add a workflow to build and release binaries automatically

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,99 @@
+name: Build and Release
+
+# Only run when a tag is pushed
+on:
+  push:
+    tags:
+      - "*"
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    env:
+      CURSEFORGE_API_KEY: ${{ secrets.CURSEFORGE_API_KEY }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: extractions/setup-just@v1
+
+      - name: Install Rust for macOS
+        if: matrix.os == 'macos-latest'
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          target: aarch64-apple-darwin
+      - name: Install Rust for Windows
+        if: matrix.os == 'windows-latest'
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+      - name: Install Rust for Linux
+        if: matrix.os == 'ubuntu-latest'
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          target: x86_64-pc-windows-gnu
+
+      - name: Install Linux dependencies
+        if: matrix.os == 'ubuntu-latest'
+        run: sudo apt-get install librust-gdk-dev gcc-mingw-w64-x86-64
+
+      - name: Lint code
+        run: just lint
+
+      - name: Run tests
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+
+      - name: Build macOS
+        if: matrix.os == 'macos-latest'
+        run: just build-mac
+      - name: Build Windows
+        if: matrix.os == 'windows-latest'
+        run: just build-win
+      - name: Build Linux
+        if: matrix.os == 'ubuntu-latest'
+        run: just build-linux
+      - name: Build Linux NoGUI
+        if: matrix.os == 'ubuntu-latest'
+        run: just build-linux-nogui
+
+      - name: Upload build artefacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: binaries
+          path: out/ferium*.zip
+          if-no-files-found: error
+
+  release:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v3
+      - name: Download artefacts
+        uses: actions/download-artifact@v3
+        with:
+          name: binaries
+          path: ./out
+      - name: Create release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: ./out/*
+          name: Ferium ${{ github.ref_name }}
+          body: |
+            Compiled binaries for Ferium version `${{ github.ref_name }}` ([changelog](https://github.com/theRookieCoder/ferium/blob/main/CHANGELOG.md#${{ github.ref_name }}))
+
+            The provided binaries are for:
+
+            - GNU Linux (x64 linux gnu) without a GUI file dialog and libraries
+            - GNU Linux (x64 linux gnu)
+            - macOS Apple Silicon (aarch64 darwin)
+            - macOS Intel (x64 darwin)
+            - GNU Windows, e.g. cygwin (x64 windows gnu)
+            - MSVC Windows (x64 windows msvc)
+
+            You can install these by downloading and unzipping the appropriate asset, and moving the executable to ~/bin or any other binary folder in your path.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog for Ferium
 
-## [3.22.0] - 24.04.2022
+## `v3.22.0`
+### 24.04.2022
 
 - Update to Libium 1.9
 - Added static variables for a yellow tick and the dialoguer colourful theme

--- a/justfile
+++ b/justfile
@@ -26,6 +26,13 @@ build-linux:
     zip -r out/ferium-linux-gnu.zip -j target/x86_64-unknown-linux-gnu/release/ferium
     zip -r out/ferium-windows-gnu.zip -j target/x86_64-pc-windows-gnu/release/ferium.exe
 
+# Build for GNU Linux without a GUI file dialog
+build-linux-nogui:
+    rm -f out/ferium-linux-gnu-nogui.zip
+    mkdir -p out
+    cargo build --target=x86_64-unknown-linux-gnu --release --no-default-features
+    zip -r out/ferium-linux-gnu-nogui.zip -j target/x86_64-unknown-linux-gnu/release/ferium
+
 # Run clippy lints
 lint:
     cargo clippy -- \

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1,5 +1,6 @@
 mod util;
 
+use libium::HOME;
 use std::fs::remove_dir;
 use util::run_command;
 
@@ -19,6 +20,8 @@ fn create_config_file_when_none() {
 
 #[test]
 fn create_profile() -> Result {
+    let mut home = HOME.clone();
+    home.push("mods");
     run_command(
         vec![
             "profile",
@@ -30,7 +33,7 @@ fn create_profile() -> Result {
             "--mod-loader",
             "forge",
             "--output-dir",
-            "/mods",
+            home.to_str().unwrap(),
         ],
         Some("empty"),
     )
@@ -38,6 +41,8 @@ fn create_profile() -> Result {
 
 #[test]
 fn create_profile_non_existent_game_version() {
+    let mut home = HOME.clone();
+    home.push("mods");
     assert!(run_command(
         vec![
             "profile",
@@ -49,7 +54,7 @@ fn create_profile_non_existent_game_version() {
             "--mod-loader",
             "forge",
             "--output-dir",
-            "/mods"
+            home.to_str().unwrap(),
         ],
         Some("empty")
     )
@@ -78,6 +83,8 @@ fn create_profile_output_dir_not_absolute() {
 
 #[test]
 fn create_profile_missing_args() {
+    let mut home = HOME.clone();
+    home.push("mods");
     assert!(run_command(
         vec![
             "profile",
@@ -88,7 +95,7 @@ fn create_profile_missing_args() {
             "--mod-loader",
             "forge",
             "--output-dir",
-            "/mods"
+            home.to_str().unwrap(),
         ],
         Some("empty")
     )
@@ -97,6 +104,8 @@ fn create_profile_missing_args() {
 
 #[test]
 fn create_profile_name_already_exists() {
+    let mut home = HOME.clone();
+    home.push("mods");
     assert!(run_command(
         vec![
             "profile",
@@ -108,7 +117,7 @@ fn create_profile_name_already_exists() {
             "--mod-loader",
             "forge",
             "--output-dir",
-            "/mods"
+            home.to_str().unwrap(),
         ],
         Some("empty_profile")
     )


### PR DESCRIPTION
Additional changes:
- Add no-gui build for linux
- Change changelog format so that releases can automatically link to them using the tagname
- Fix the directory for the integration tests on Windows

This will fix #20 and allow the AUR builds to work without GTK