### PR TITLE
Update AUR packages in the build and release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,10 +79,17 @@ jobs:
         with:
           name: binaries
           path: ./out
-      - name: Upload to the AUR
+      - name: Upload to the AUR(nogui)
         uses: ATiltedTree/create-aur-release@v1
         with:
           package_name: ferium-bin
+          commit_username: "Ilesh Thiada"
+          commit_email: ileshkt@gmail.com
+          ssh_private_key: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
+      - name: Upload to the AUR(with gui)
+        uses: ATiltedTree/create-aur-release@v1
+        with:
+          package_name: ferium-gui-bin
           commit_username: "Ilesh Thiada"
           commit_email: ileshkt@gmail.com
           ssh_private_key: ${{ secrets.AUR_SSH_PRIVATE_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,36 +79,13 @@ jobs:
         with:
           name: binaries
           path: ./out
-      - name: Get ssh permission
-        run: |
-          mkdir ~/.ssh
-          touch ~/.ssh/known_hosts
-          ssh-keyscan -v -t ssh-rsa aur.archlinux.org >>~/.ssh/known_hosts
-          echo "Host aur.archlinux.org" >> ~/.ssh/config
-          echo "  IdentityFile ~/.ssh/aur" >> ~/.ssh/config
-          echo "  User aur" >> ~/.ssh/config
-          echo "${{ secrets.PRIVATE }}" >> ~/.ssh/aur
-          chmod -vR 600 ~/.ssh/aur
-          ssh-keygen -vy -f ~/.ssh/aur >~/.ssh/aur.pub
-      - name: Download ferium from AUR
-        run: git clone ssh://aur@aur.archlinux.org/ferium-bin.git
-      - name: Upgrade PKGBUILD
-        uses: hapakaien/archlinux-package-action@v2
-        with:
-          path: ./ferium-bin/
-          pkgver: '${{ github.ref_name }}'
-          updpkgsums: true
-          srcinfo: true
-          flags: ''
       - name: Upload to the AUR
-        run: |
-          cd ferium-bin
-          git config --global user.email "shiue.kyle@gmail.com"
-          git config --global user.name "KyleUltimate"
-          git add .
-          git commit -m "Auto update to ${{ github.ref_name }}"
-          git remote add aur "ssh://aur@aur.archlinux.org/ferium-bin"
-          git push origin master
+        uses: ATiltedTree/create-aur-release@v1
+        with:
+          package_name: ferium-bin
+          commit_username: "Ilesh Thiada"
+          commit_email: ileshkt@gmail.com
+          ssh_private_key: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
       - name: Create release
         uses: softprops/action-gh-release@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,6 +79,36 @@ jobs:
         with:
           name: binaries
           path: ./out
+      - name: Get ssh permission
+        run: |
+          mkdir ~/.ssh
+          touch ~/.ssh/known_hosts
+          ssh-keyscan -v -t ssh-rsa aur.archlinux.org >>~/.ssh/known_hosts
+          echo "Host aur.archlinux.org" >> ~/.ssh/config
+          echo "  IdentityFile ~/.ssh/aur" >> ~/.ssh/config
+          echo "  User aur" >> ~/.ssh/config
+          echo "${{ secrets.PRIVATE }}" >> ~/.ssh/aur
+          chmod -vR 600 ~/.ssh/aur
+          ssh-keygen -vy -f ~/.ssh/aur >~/.ssh/aur.pub
+      - name: Download ferium from AUR
+        run: git clone ssh://aur@aur.archlinux.org/ferium-bin.git
+      - name: Upgrade PKGBUILD
+        uses: hapakaien/archlinux-package-action@v2
+        with:
+          path: ./ferium-bin/
+          pkgver: '${{ github.ref_name }}'
+          updpkgsums: true
+          srcinfo: true
+          flags: ''
+      - name: Upload to the AUR
+        run: |
+          cd ferium-bin
+          git config --global user.email "shiue.kyle@gmail.com"
+          git config --global user.name "KyleUltimate"
+          git add .
+          git commit -m "Auto update to ${{ github.ref_name }}"
+          git remote add aur "ssh://aur@aur.archlinux.org/ferium-bin"
+          git push origin master
       - name: Create release
         uses: softprops/action-gh-release@v1
         with:


### PR DESCRIPTION
This should automatically update the AUR via actions.
you have to set the ssh secret in order to let it work.
I have a question though, is github.ref_name the version number?
This is the correct branch :rofl: 