### PR TITLE
Separate Windows/Linux glibc buildscript and Intel/Arm MacOS buildscripts.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,13 +17,13 @@ jobs:
       - uses: actions/checkout@v3
       - uses: extractions/setup-just@v1
 
-      - name: Install Rust for macOS Intel
+      - name: Install Rust for Intel macOS
         if: matrix.os == 'macos-latest'
         uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
-          target: aarch64-apple-darwin
-      - name: Install Rust for macOS
+          target: x86_64-apple-darwin
+      - name: Install Rust for M1 macOS
         if: matrix.os == 'macos-latest'
         uses: actions-rs/toolchain@v1
         with:
@@ -34,12 +34,18 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
-      - name: Install Rust for Linux
+      - name: Install Rust for Glibc Linux
         if: matrix.os == 'ubuntu-latest'
         uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
           target: x86_64-unknown-linux-gnu
+      - name: Install Rust for Glibc Windows
+        if: matrix.os == 'ubuntu-latest'
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          target: x86_64-pc-windows-gnu
 
       - name: Install Linux dependencies
         if: matrix.os == 'ubuntu-latest'
@@ -59,7 +65,7 @@ jobs:
         if: matrix.os == 'macos-latest'
         run: |
           just build-mac-intel
-          just build-mac-arm
+          just build-mac-m1
       - name: Build Windows MSVC
         if: matrix.os == 'windows-latest'
         run: just build-win

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,80 @@
+name: Build
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: extractions/setup-just@v1
+
+      - name: Install Rust for macOS Intel
+        if: matrix.os == 'macos-latest'
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          target: aarch64-apple-darwin
+      - name: Install Rust for macOS
+        if: matrix.os == 'macos-latest'
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          target: aarch64-apple-darwin
+      - name: Install Rust for Windows
+        if: matrix.os == 'windows-latest'
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+      - name: Install Rust for Linux
+        if: matrix.os == 'ubuntu-latest'
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          target: x86_64-unknown-linux-gnu
+
+      - name: Install Linux dependencies
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          sudo apt-get update
+          sudo apt-get install librust-gdk-dev gcc-mingw-w64-x86-64
+
+      - name: Lint code
+        run: just lint
+
+      - name: Run tests
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+
+      - name: Build macOS
+        if: matrix.os == 'macos-latest'
+        run: |
+          just build-mac-intel
+          just build-mac-arm
+      - name: Build Windows MSVC
+        if: matrix.os == 'windows-latest'
+        run: just build-win
+      - name: Build Linux
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          just build-linux
+          just build-windows-glibc
+      - name: Build Linux NoGUI
+        if: matrix.os == 'ubuntu-latest'
+        run: just build-linux-nogui
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: binaries
+          path: out/ferium*.zip
+          if-no-files-found: error

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,12 @@ jobs:
       - uses: actions/checkout@v3
       - uses: extractions/setup-just@v1
 
+      - name: Install Rust for macOS Intel
+        if: matrix.os == 'macos-latest'
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          target: aarch64-apple-darwin
       - name: Install Rust for macOS
         if: matrix.os == 'macos-latest'
         uses: actions-rs/toolchain@v1
@@ -34,7 +40,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
-          target: x86_64-pc-windows-gnu
+          target: x86_64-unknown-linux-gnu
 
       - name: Install Linux dependencies
         if: matrix.os == 'ubuntu-latest'
@@ -52,18 +58,22 @@ jobs:
 
       - name: Build macOS
         if: matrix.os == 'macos-latest'
-        run: just build-mac
-      - name: Build Windows
+        run: |
+          just build-mac-intel
+          just build-mac-arm
+      - name: Build Windows MSVC
         if: matrix.os == 'windows-latest'
         run: just build-win
       - name: Build Linux
         if: matrix.os == 'ubuntu-latest'
-        run: just build-linux
+        run: |
+          just build-linux
+          just build-windows-glibc
       - name: Build Linux NoGUI
         if: matrix.os == 'ubuntu-latest'
         run: just build-linux-nogui
 
-      - name: Upload build artefacts
+      - name: Upload build artifacts
         uses: actions/upload-artifact@v3
         with:
           name: binaries

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,13 +18,13 @@ jobs:
       - uses: actions/checkout@v3
       - uses: extractions/setup-just@v1
 
-      - name: Install Rust for macOS Intel
+      - name: Install Rust for Intel macOS
         if: matrix.os == 'macos-latest'
         uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
-          target: aarch64-apple-darwin
-      - name: Install Rust for macOS
+          target: x86_64-apple-darwin
+      - name: Install Rust for M1 macOS
         if: matrix.os == 'macos-latest'
         uses: actions-rs/toolchain@v1
         with:
@@ -35,12 +35,18 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
-      - name: Install Rust for Linux
+      - name: Install Rust for Glibc Linux
         if: matrix.os == 'ubuntu-latest'
         uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
           target: x86_64-unknown-linux-gnu
+      - name: Install Rust for Glibc Windows
+        if: matrix.os == 'ubuntu-latest'
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          target: x86_64-pc-windows-gnu
 
       - name: Install Linux dependencies
         if: matrix.os == 'ubuntu-latest'
@@ -60,7 +66,7 @@ jobs:
         if: matrix.os == 'macos-latest'
         run: |
           just build-mac-intel
-          just build-mac-arm
+          just build-mac-m1
       - name: Build Windows MSVC
         if: matrix.os == 'windows-latest'
         run: just build-win

--- a/justfile
+++ b/justfile
@@ -1,15 +1,20 @@
 default: install-dev
 set windows-powershell := true
 
-# Build for macOS Intel and macOS Apple Silicon
-build-mac:
-    rm -f out/ferium-macos-x64.zip out/ferium-macos-arm.zip
+# Build for macOS Intel
+build-mac-intel:
+    rm -f out/ferium-macos-x64.zip
     mkdir -p out
     cargo build --target=x86_64-apple-darwin --release
-    cargo build --target=aarch64-apple-darwin --release
     zip -r out/ferium-macos-x64.zip -j target/x86_64-apple-darwin/release/ferium
-    zip -r out/ferium-macos-arm.zip -j target/aarch64-apple-darwin/release/ferium
 
+# Build for macOS Apple Silicon
+build-mac-m1:
+    rm -f out/ferium-macos-arm.zip
+    mkdir -p out
+    cargo build --target=aarch64-apple-darwin --release
+    zip -r out/ferium-macos-arm.zip -j target/aarch64-apple-darwin/release/ferium
+    
 # Build for Windows MSVC
 build-win:
     if (Test-Path -Path ".\out\ferium-windows-msvc.zip") { Remove-Item -Path ".\out\ferium-windows-msvc.zip" }
@@ -17,16 +22,21 @@ build-win:
     cargo build --target=x86_64-pc-windows-msvc --release
     Compress-Archive -Path "target\x86_64-pc-windows-msvc\release\ferium.exe" -DestinationPath "out\ferium-windows-msvc.zip"
 
-# Build for GNU Linux and GNU Windows (e.g. cygwin)
+# Build for glibc Linux
 build-linux:
-    rm -f out/ferium-linux-gnu.zip out/ferium-windows-gnu.zip
+    rm -f out/ferium-linux-gnu.zip
     mkdir -p out
-    cargo build --target=x86_64-pc-windows-gnu --release
     cargo build --target=x86_64-unknown-linux-gnu --release
     zip -r out/ferium-linux-gnu.zip -j target/x86_64-unknown-linux-gnu/release/ferium
+    
+# Build for glibc Windows (e.g. Cygwin)
+build-windows-glibc:
+    rm -f out/ferium-windows-gnu.zip
+    mkdir -p out
+    cargo build --target=x86_64-pc-windows-gnu --release
     zip -r out/ferium-windows-gnu.zip -j target/x86_64-pc-windows-gnu/release/ferium.exe
 
-# Build for GNU Linux without a GUI file dialog
+# Build for glibc Linux without a GUI file dialog
 build-linux-nogui:
     rm -f out/ferium-linux-gnu-nogui.zip
     mkdir -p out


### PR DESCRIPTION
Fixes #69.

Also add CI workflow to build on PRs, pushes, and manual commits to make sure contributors' code actually builds.